### PR TITLE
PeripheralCecAdapter: remove HDMI port and use physical address setting

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -17792,7 +17792,7 @@ msgstr ""
 
 #: system/peripherals.xml
 msgctxt "#36021"
-msgid "Physical address (overrules HDMI port)"
+msgid "Physical address"
 msgstr ""
 
 #empty string with id 36022

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -22,20 +22,18 @@
     <setting key="use_tv_menu_language" type="bool" value="0" label="36018" order="11" />
     <setting key="pause_playback_on_deactivate" type="bool" value="1" label="36033" configurable="0" />
     <setting key="pause_or_stop_playback_on_deactivate" type="enum" value="231" label="36033" order="12" lvalues="231|36044|36045" />
-    <setting key="connected_device" type="enum" label="36019" value="36037" lvalues="36037|36038" order="13" />
-    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="15" label="36015" order="14" />
-    <setting key="physical_address" type="string" label="36021" value="0" order="15" />
-    <setting key="power_avr_on_as" type="bool" label="36046" value="0" order="16" />
+    <setting key="physical_address" type="string" label="36021" value="0" order="13" />
+    <setting key="power_avr_on_as" type="bool" label="36046" value="0" order="14" />
 
     <setting key="tv_vendor" type="int" value="0" configurable="0" />
     <setting key="device_name" type="string" value="CoreELEC" configurable="0" />
     <setting key="device_type" type="int" value="1" configurable="0" />
     <setting key="wake_devices_advanced" type="string" value="" configurable="0" />
     <setting key="standby_devices_advanced" type="string" value="" configurable="0" />
-    <setting key="double_tap_timeout_ms" type="int" min="50" max="1000" step="50" value="300" label="36047" order="17" />
-    <setting key="button_repeat_rate_ms" type="int" min="0" max="250" step="10" value="0" label="36048" order="18" />
-    <setting key="button_release_delay_ms" type="int" min="0" max="500" step="50" value="0" label="36049" order="19" />
-    <setting key="screensaver_delay_standby" type="int" min="0" max="7200" step="10" value="0" label="36051" order="20" />
+    <setting key="double_tap_timeout_ms" type="int" min="50" max="1000" step="50" value="300" label="36047" order="15" />
+    <setting key="button_repeat_rate_ms" type="int" min="0" max="250" step="10" value="0" label="36048" order="16" />
+    <setting key="button_release_delay_ms" type="int" min="0" max="500" step="50" value="0" label="36049" order="17" />
+    <setting key="screensaver_delay_standby" type="int" min="0" max="7200" step="10" value="0" label="36051" order="18" />
   </peripheral>
 
   <peripheral vendor_product="2548:1001,2548:1002" bus="usb" name="Pulse-Eight CEC Adapter" mapTo="cec">

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1194,30 +1194,8 @@ void CPeripheralCecAdapter::SetConfigurationFromLibCEC(const CEC::libcec_configu
   m_configuration.deviceTypes.Clear();
   m_configuration.deviceTypes.Add(config.deviceTypes[0]);
 
-  // hide the "connected device" and "hdmi port number" settings when the PA was autodetected
-  bool bPAAutoDetected(config.bAutodetectAddress == 1);
-
-  SetSettingVisible("connected_device", !bPAAutoDetected);
-  SetSettingVisible("cec_hdmi_port", !bPAAutoDetected);
-
   // set the connected device
   m_configuration.baseDevice = config.baseDevice;
-  bChanged |= SetSetting("connected_device", config.baseDevice == CECDEVICE_AUDIOSYSTEM ? LOCALISED_ID_AVR : LOCALISED_ID_TV);
-
-  // set the HDMI port number
-  m_configuration.iHDMIPort = config.iHDMIPort;
-  bChanged |= SetSetting("cec_hdmi_port", config.iHDMIPort);
-
-  // set the physical address, when baseDevice or iHDMIPort are not set
-  std::string strPhysicalAddress("0");
-  if (!bPAAutoDetected && (m_configuration.baseDevice == CECDEVICE_UNKNOWN ||
-      m_configuration.iHDMIPort < CEC_MIN_HDMI_PORTNUMBER ||
-      m_configuration.iHDMIPort > CEC_MAX_HDMI_PORTNUMBER))
-  {
-    m_configuration.iPhysicalAddress = config.iPhysicalAddress;
-    strPhysicalAddress = StringUtils::Format("%x", config.iPhysicalAddress);
-  }
-  bChanged |= SetSetting("physical_address", strPhysicalAddress);
 
   // set the devices to wake when starting
   m_configuration.wakeDevices = config.wakeDevices;
@@ -1275,7 +1253,7 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
   m_configuration.bAutodetectAddress = CEC_DEFAULT_SETTING_AUTODETECT_ADDRESS;
 
   // set the physical address
-  // when set, it will override the connected device and hdmi port settings
+  // when set, it will override the connected device
   std::string strPhysicalAddress = GetSettingString("physical_address");
   int iPhysicalAddress;
   if (sscanf(strPhysicalAddress.c_str(), "%x", &iPhysicalAddress) &&
@@ -1285,18 +1263,8 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
   else
     m_configuration.iPhysicalAddress = CEC_PHYSICAL_ADDRESS_TV;
 
-  // set the connected device
-  int iConnectedDevice = GetSettingInt("connected_device");
-  if (iConnectedDevice == LOCALISED_ID_AVR)
-    m_configuration.baseDevice = CECDEVICE_AUDIOSYSTEM;
-  else if (iConnectedDevice == LOCALISED_ID_TV)
-    m_configuration.baseDevice = CECDEVICE_TV;
-
-  // set the HDMI port number
-  int iHDMIPort = GetSettingInt("cec_hdmi_port");
-  if (iHDMIPort >= CEC_MIN_HDMI_PORTNUMBER &&
-      iHDMIPort <= CEC_MAX_HDMI_PORTNUMBER)
-    m_configuration.iHDMIPort = iHDMIPort;
+  // reset the HDMI port number
+  m_configuration.iHDMIPort = CEC_HDMI_PORTNUMBER_NONE;
 
   // set the tv vendor override
   int iVendor = GetSettingInt("tv_vendor");


### PR DESCRIPTION
By the HDMI port option it was not possible to represent all hardware setups available on user side.
Also the HDMI port setting was transfered to the corresponding physical address by libCEC on the first init anyway.

The physical address in Kodi/input is now set only by user, not by auto detection anymore.
If the user change the physical address it will be forced to use user setting instead auto detection.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
